### PR TITLE
fix getDamlDependencies for the first project without an external dep

### DIFF
--- a/scripts/getDamlDependencies.sh
+++ b/scripts/getDamlDependencies.sh
@@ -20,7 +20,7 @@ function getDependencyLinesWithProperErrorHandling() {
 project_dir="$1"
 # yq would be more reliable, but 5-10x slower
 deps=$( getDependencyLinesWithProperErrorHandling | sed "s|^  - |$project_dir/|" )
-[ -n "$deps" ] && realpath -m --relative-to="${PWD}" ${deps}
+[ -n "${deps}" ] && realpath -m --relative-to="${PWD}" ${deps}
 
 # TODO - this should be using the source field from daml.yaml
 echo "$project_dir"/daml.yaml

--- a/scripts/getDamlDependencies.sh
+++ b/scripts/getDamlDependencies.sh
@@ -8,8 +8,13 @@ set -euo pipefail
 
 project_dir="$1"
 # yq would be more reliable, but 5-10x slower
-deps=$(grep -E '^  - .*/.daml/dist/.*dar$' "$project_dir"/daml.yaml | sed "s|^  - |$project_dir/|")
-[ -n "${deps}" ] && realpath -m --relative-to="${PWD}" ${deps}
+deps=$(
+  (
+    grep -E '^  - .*/.daml/dist/.*dar$' "$project_dir"/daml.yaml
+    if [ $? = 2 ] ; then exit 1 ; fi # grep returns 1 if no lines were selected :-(
+  ) | sed "s|^  - |$project_dir/|"
+)
+[ -n "$deps" ] && realpath -m --relative-to="${PWD}" ${deps}
 
 # TODO - this should be using the source field from daml.yaml
 echo "$project_dir"/daml.yaml

--- a/scripts/getDamlDependencies.sh
+++ b/scripts/getDamlDependencies.sh
@@ -6,14 +6,20 @@
 
 set -euo pipefail
 
+function getDependencyLinesWithProperErrorHandling() {
+  grep -E '^  - .*/.daml/dist/.*dar$' "$project_dir"/daml.yam
+  # grep returns 1 if no lines were selected, 2 on error :-(
+  if [ $? = 2 ]
+  then
+    return 1
+  else
+    return 0
+  fi
+}
+
 project_dir="$1"
 # yq would be more reliable, but 5-10x slower
-deps=$(
-  (
-    grep -E '^  - .*/.daml/dist/.*dar$' "$project_dir"/daml.yaml
-    if [ $? = 2 ] ; then exit 1 ; fi # grep returns 1 if no lines were selected :-(
-  ) | sed "s|^  - |$project_dir/|"
-)
+deps=$( getDependencyLinesWithProperErrorHandling | sed "s|^  - |$project_dir/|" )
 [ -n "$deps" ] && realpath -m --relative-to="${PWD}" ${deps}
 
 # TODO - this should be using the source field from daml.yaml


### PR DESCRIPTION
Without this fix, it gives an empty dependency list, however, we need this (achieving with this fix) :
```
$ scripts/getDamlDependencies.sh lib
lib/daml.yaml
lib/daml/DA/Lib/Types/Sector.daml
```

It still handles real errors properly:
```
$ scripts/getDamlDependencies.sh lib
grep: lib/daml.yam: No such file or directory
$ echo $?
1
```